### PR TITLE
Add LIBGBA to libdirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ LIBS	:=	-ltonc -lmm
 # include and lib
 #---------------------------------------------------------------------------------
 # LIBDIRS	:=	$(LIBGBA) $(LIBTONC)
-LIBDIRS	:= $(LIBTONC)
+LIBDIRS	:= $(LIBGBA) $(LIBTONC)
 
 #---------------------------------------------------------------------------------
 # no real need to edit anything past this point unless you need to add additional


### PR DESCRIPTION
In current devkitarm installations, `libmm` (maxmod, required by `-lmm`) is only in the LIBGBA libdir. Tested on a system with a fresh devkitarm install.